### PR TITLE
add: 新增支持标志接口是否被弃用

### DIFF
--- a/restgen/doc.go
+++ b/restgen/doc.go
@@ -136,13 +136,14 @@ func (api *API) Tags() []string {
 
 // api
 type APIObject struct {
-	OperartionID string                  `yaml:"operationId"`
-	Tags         []string                `yaml:"tags"`
-	HCIVersions  []string                `yaml:"x-hci-versions,omitempty"`
-	RequestBody  *APIRequestBody         `yaml:"requestBody,omitempty"`
-	Parameters   []*APIParameter         `yaml:"parameters,omitempty"`
-	Description  string                  `yaml:"description,omitempty"`
-	Responses    map[string]*APIResponse `yaml:"responses"`
+	OperationID string                  `yaml:"operationId"`
+	Tags        []string                `yaml:"tags"`
+	Deprecated  *bool                   `yaml:"deprecated,omitempty"`
+	HCIVersions []string                `yaml:"x-hci-versions,omitempty"`
+	RequestBody *APIRequestBody         `yaml:"requestBody,omitempty"`
+	Parameters  []*APIParameter         `yaml:"parameters,omitempty"`
+	Description string                  `yaml:"description,omitempty"`
+	Responses   map[string]*APIResponse `yaml:"responses"`
 }
 
 type APIParameter struct {
@@ -510,11 +511,18 @@ func (m *DocPlugin) parseAPI(data *codegen.Object, apis map[string]*API, compone
 						versions := strings.Split(strings.ReplaceAll(value, "]", ""), ",")
 						obj.HCIVersions = append(obj.HCIVersions, versions...)
 					}
+				} else if arg.Name == "deprecated" {
+					deprecated, err := strconv.ParseBool(arg.Value.String())
+					if err != nil {
+						dbgPrintf("parse operationId:%v deprecated value:%v to bool error:%v", field.Name, arg.Value.String(), err.Error())
+					} else if deprecated {
+						obj.Deprecated = &deprecated
+					}
 				}
 			}
 		}
 
-		obj.OperartionID = field.Name
+		obj.OperationID = field.Name
 		obj.Description = field.Description
 
 		responseName := strings.Title(field.Name) + "Response"


### PR DESCRIPTION
在tag指令中，添加废弃接口的标记deprecated，表示接口是否被弃用。
deprecated添加到tag指令中进行使用，具体使用示例：
```
	"""
	创建告警
	"""
	createAlarm(
		"""
		创建告警入参
		"""
		input: CreateAlarmInput!
	): SyncOperation!
		@http(url: "/api/v1/alarms")
		@tag(deprecated: true)
```
说明：deprecated: true表示该接口被弃用，如果接口没被弃用，则不需要添加deprecated标志。