### PR TITLE
fix: restful请求若不传Content-Type则默认是application/json；导出yaml删除requestBody中和url对应的参数

### DIFF
--- a/handlerx/httppost.go
+++ b/handlerx/httppost.go
@@ -20,10 +20,16 @@ func (h POST) Supports(r *http.Request) bool {
 		return false
 	}
 
+	// 如果 Content-Type 头部不存在，则会被放通
 	mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
-	if err != nil || mediaType != "application/json" {
+	if err != nil && err.Error() != "mime: no media type" {
 		return false
 	}
+
+	if mediaType != "" && mediaType != "application/json" {
+		return false
+	}
+
 	return r.Method == "POST" || r.Method == "PUT" || r.Method == "PATCH"
 }
 

--- a/handlerx/mapping.go
+++ b/handlerx/mapping.go
@@ -42,7 +42,6 @@ func SetupHTTP2GraphQLMapping(operations StringMap, selections StringMap,
 func convertHTTPRequestToGraphQLQuery(r *http.Request, params *graphql.RawParams, body []byte) (string, error) {
 	// DbgPrintf(r, "ADE: http.POST: %#v", r.URL.Path)
 	// DbgPrintf(r, "ADE: http.POST: %#v", r.URL.Query())
-
 	var bodyParams map[string]interface{}
 	if len(body) > 0 {
 		bodyReader := ioutil.NopCloser(bytes.NewBuffer(body))


### PR DESCRIPTION
本次改动：
1、导出yaml时，将requestBody中和url path对应的参数进行删除，并判断requestBody为空，则不导出requestBody
2、RESTful请求POST/PUT/PATCH方法接口，Content-Type必须为application/json，Content-Type为空时，设置默认值为application/json